### PR TITLE
Ignora colonne per determinare se riga doppia

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -14,7 +14,8 @@ class Configuration:
             config['generali'] = {
                 'debug_mode': 'false',
                 'cf_amministrazione': '00124430323',
-                'ignora_colonne': 'COD_CPV,DESCRIZIONE_CPV,FLAG_PREVALENTE'
+                'ignora_colonne': 'COD_CPV,DESCRIZIONE_CPV,FLAG_PREVALENTE',
+                'ignora_colonne_per_duplicati': 'CIG,ID_AGGIUDICAZIONE'
             }
             config['cartelle'] = {
                 'cartella_cig': 'cig',
@@ -36,6 +37,9 @@ class Configuration:
         
     def get_columns_to_ignore(self) -> list[str]:
         return self._get_list_from_value(self._config_file.get('generali', 'ignora_colonne', fallback=''), True)
+    
+    def get_columns_to_ignore_for_duplicates(self) -> list[str]:
+        return self._get_list_from_value(self._config_file.get('generali', 'ignora_colonne_per_duplicati', fallback=''), True)
         
     def get_cf_amministrazione(self) -> str:
         return self._config_file.get('generali', 'cf_amministrazione', fallback='00124430323')

--- a/result_sheet.py
+++ b/result_sheet.py
@@ -103,7 +103,7 @@ class ResultSheet:
         found = False
         for column_name, column_value in line.items():
             column_name = column_name.upper()
-            if column_name == 'CIG':
+            if column_name in self._config.get_columns_to_ignore_for_duplicates():
                 continue
             if column_name in self._columns_map:
                 column_key = self._columns_map.index(column_name)


### PR DESCRIPTION
Prima di questa patch l'unica colonna che veniva ignorata per tentare di capire se il tipo di file in fase di analisi fosse già stato aggiunto per il relativo CIG era il campo CIG (perchè presente in ogni file comunemente usato), i file relativi a "fine contratto" però hanno anche il campo 'id aggiudicazione' che è già presente in altri file, con il risultato che la fine contratto non compariva mai nel foglio principale.

Questa patch consente di aggiungere questo tipo di colonne nel file di configurazione, permettendo di ignorarle quando viene valutato se il loro contenuto è già presente nel foglio principale.

Questa soluzione potrebbe creare problemi nel caso in cui ci siano più elementi (ad esempio ci siano effettivamente più aggiudicazioni sullo stesso CIG), ma dovrebbe trattarsi di casi estremi.